### PR TITLE
Syntax highlighting for ImportSorter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ import D
 
 will be:
 
-```diff
+```swift
 import A
 import B
 import C


### PR DESCRIPTION
The ImportSorted "will be" example were missing syntax highlighting. 