### PR TITLE
Improve `TokenSyntax.with(lens:replacingLastSpaces:)`

### DIFF
--- a/Sources/SwiftRewriter/Extensions/TokenSyntax.swift
+++ b/Sources/SwiftRewriter/Extensions/TokenSyntax.swift
@@ -124,7 +124,7 @@ extension TokenSyntax
     /// Replace `leadingTrivia` / `trailingTrivia`'s last spaces.
     func with(
         _ lens: Lens<TokenSyntax, [TriviaPiece]>,
-        replacingLastSpaces spaces: Int
+        replacingLastSpaces lastPieces: [TriviaPiece]
         ) -> TokenSyntax
     {
         var pieces = lens.getter(self)
@@ -139,9 +139,7 @@ extension TokenSyntax
             }
         }
 
-        if spaces > 0 {
-            pieces.append(.spaces(spaces))
-        }
+        pieces.append(contentsOf: lastPieces)
 
         var token2 = self
         token2 = lens.setter(self, pieces)
@@ -151,7 +149,7 @@ extension TokenSyntax
     /// Replace `leadingTrivia` / `trailingTrivia`'s first spaces.
     func with(
         _ lens: Lens<TokenSyntax, [TriviaPiece]>,
-        replacingFirstSpaces spaces: Int
+        replacingFirstSpaces firstPieces: [TriviaPiece]
         ) -> TokenSyntax
     {
         var pieces = lens.getter(self)
@@ -162,9 +160,7 @@ extension TokenSyntax
             pieces.removeFirst(removalCount)
         }
 
-        if spaces > 0 {
-            pieces.insert(.spaces(spaces), at: 0)
-        }
+        pieces.insert(contentsOf: firstPieces, at: 0)
 
         var token2 = self
         token2 = lens.setter(self, pieces)

--- a/Sources/SwiftRewriter/Rewriters/Space/ExtraSpaceTrimmer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Space/ExtraSpaceTrimmer.swift
@@ -16,7 +16,9 @@ open class ExtraSpaceTrimmer: SyntaxRewriter
 
         if token.leadingTriviaLength.newlines == 0 && !self._skipsNextLeadingTriva
         {
-            let lastSpaces = token.leadingTrivia.pieces.last?.isSpace == true ? 1 : 0
+            let lastSpaces = token.leadingTrivia.pieces.last?.isSpace == true
+                ? [TriviaPiece.spaces(1)]
+                : []
             token2 = token2.with(.leadingTrivia, replacingLastSpaces: lastSpaces)
         }
 
@@ -27,7 +29,9 @@ open class ExtraSpaceTrimmer: SyntaxRewriter
             self._skipsNextLeadingTriva = true
         }
         else if token.trailingTriviaLength.newlines == 0 {
-            let firstSpaces = token.trailingTrivia.pieces.first?.isSpace == true ? 1 : 0
+            let firstSpaces = token.trailingTrivia.pieces.first?.isSpace == true
+                ? [TriviaPiece.spaces(1)]
+                : []
             token2 = token2.with(.trailingTrivia, replacingFirstSpaces: firstSpaces)
         }
 

--- a/Sources/SwiftRewriter/Rewriters/Space/TrailingSpaceTrimmer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Space/TrailingSpaceTrimmer.swift
@@ -15,7 +15,7 @@ open class TrailingSpaceTrimmer: SyntaxRewriter
         var token2 = token
 
         if isTrailingToken {
-            token2 = token.with(.trailingTrivia, replacingFirstSpaces: 0)
+            token2 = token.with(.trailingTrivia, replacingFirstSpaces: [])
         }
 
         return super.visit(token2)

--- a/Sources/SwiftRewriter/Utilities/TokenHandler.swift
+++ b/Sources/SwiftRewriter/Utilities/TokenHandler.swift
@@ -105,15 +105,15 @@ extension OptionalKleisli
     private static func _handleTrailingSpacesBefore(shouldInsert: Bool) -> TokenHandler
     {
         return shouldInsert
-            ? TokenHandler { $0.with(.trailingTrivia, replacingLastSpaces: 1) }
-            : TokenHandler { $0.with(.trailingTrivia, replacingLastSpaces: 0) }
+            ? TokenHandler { $0.with(.trailingTrivia, replacingLastSpaces: [.spaces(1)]) }
+            : TokenHandler { $0.with(.trailingTrivia, replacingLastSpaces: []) }
     }
 
     /// Replace `trailingTrivia`'s first spaces.
     private static func _handleTrailingSpacesAfter(shouldInsert: Bool) -> TokenHandler
     {
         return shouldInsert
-            ? TokenHandler { $0.with(.trailingTrivia, replacingFirstSpaces: 1) }
-            : TokenHandler { $0.with(.trailingTrivia, replacingFirstSpaces: 0) }
+            ? TokenHandler { $0.with(.trailingTrivia, replacingFirstSpaces: [.spaces(1)]) }
+            : TokenHandler { $0.with(.trailingTrivia, replacingFirstSpaces: []) }
     }
 }


### PR DESCRIPTION
This PR improves `TokenSyntax.with(lens:replacingLastSpaces:)` and `TokenSyntax.with(lens:replacingFirstSpaces:)` that can append/prepend arbitrary `TriviaPiece`s.