### PR TITLE
Add `MethodChainNewliner`

### DIFF
--- a/Sources/SwiftRewriter/Rewriters/Newline/MethodChainNewliner.swift
+++ b/Sources/SwiftRewriter/Rewriters/Newline/MethodChainNewliner.swift
@@ -1,0 +1,54 @@
+import SwiftSyntax
+
+/// Add a newline before method-chaining's `dot` if preceding block is multiline.
+///
+/// # Example
+///
+///     foo
+///         .bar {
+///             // long block
+///         }.baz
+///
+/// will have `.baz` be newlined:
+///
+///     foo
+///         .bar {
+///             // long block
+///         }
+///         .baz
+///
+/// but won't be newlined if not enough "long block",
+/// so that one-liner `foo().bar { }.baz` won't be newlined every time.
+///
+/// - Postcondition: Use `Indenter` for better indent.
+open class MethodChainNewliner: SyntaxRewriter
+{
+    open override func visit(_ syntax: MemberAccessExprSyntax) -> ExprSyntax
+    {
+        // Skip already newlined `dot`.
+        guard syntax.dot.leadingTriviaLength.newlines == 0 else {
+            return super.visit(syntax)
+        }
+
+        var syntax2 = syntax
+
+        // If `foo.bar().baz` ...
+        if let funcCall = syntax2.base as? FunctionCallExprSyntax,
+            let memberAccess2 = funcCall.calledExpression as? MemberAccessExprSyntax
+        {
+            // If `funcCall - memberAccess2` (= func arg content) has multiple lines,
+            // let `dot` have a newline.
+            if funcCall.contentLength.newlines - memberAccess2.contentLength.newlines > 0 {
+                var dot = syntax2.dot
+                dot = dot.with(.leadingTrivia, replacingLastSpaces: [.newlines(1)])
+                syntax2 = syntax2.withDot(dot)
+            }
+        }
+        // If `foo.bar.baz` or `foo.bar` (no more method-chain) ...
+        else {
+            // Do nothing.
+        }
+
+        return super.visit(syntax2)
+    }
+}

--- a/Sources/swift-rewriter/rewriter.swift
+++ b/Sources/swift-rewriter/rewriter.swift
@@ -16,6 +16,7 @@ var rewriter: Rewriter {
         // Newline
 //        >>> ExtraNewliner()   // not useful for everyone
         >>> ElseNewliner(newline: false)
+        >>> MethodChainNewliner()
 
         // Indent
         >>> Indenter(.init(

--- a/Tests/SwiftRewriterTests/Combined/CombinedTests.swift
+++ b/Tests/SwiftRewriterTests/Combined/CombinedTests.swift
@@ -18,5 +18,10 @@ final class CombinedTests: XCTestCase
             let rewriter = ExtraNewliner()
             try runTestFile("densed", using: rewriter)
         }
+
+        do {
+            let rewriter = MethodChainNewliner()
+            try runTestFile("method-chain", using: rewriter)
+        }
     }
 }

--- a/Tests/SwiftRewriterTests/Combined/__Snapshots__/CombinedTests/test.example.swift
+++ b/Tests/SwiftRewriterTests/Combined/__Snapshots__/CombinedTests/test.example.swift
@@ -66,7 +66,8 @@ api.send {
     $0.run {
         $0
     }
-    }.foo()
+    }
+    .foo()
     .bar()
     .foo {
         print()

--- a/Tests/SwiftRewriterTests/Combined/__Snapshots__/CombinedTests/test.method-chain.swift
+++ b/Tests/SwiftRewriterTests/Combined/__Snapshots__/CombinedTests/test.method-chain.swift
@@ -1,0 +1,16 @@
+indexPath = section.lazy
+    .enumerated()
+    .compactMap { (offset: Int, element: [SectionElement]) -> IndexPath? in
+        let row = element.lazy
+            .enumerated()
+            .compactMap { (offset: Int, element: SectionElement) -> Int? in
+                if element == .section1(.flag) {
+                    return offset
+                } else {
+                    return nil
+                }
+            }
+.first
+        return row.map { IndexPath(row: $0, section: offset) }
+    }
+.first!

--- a/Tests/SwiftRewriterTests/Combined/__TestSources__/CombinedTests/test.method-chain.swift
+++ b/Tests/SwiftRewriterTests/Combined/__TestSources__/CombinedTests/test.method-chain.swift
@@ -1,0 +1,14 @@
+indexPath = section.lazy
+    .enumerated()
+    .compactMap { (offset: Int, element: [SectionElement]) -> IndexPath? in
+        let row = element.lazy
+            .enumerated()
+            .compactMap { (offset: Int, element: SectionElement) -> Int? in
+                if element == .section1(.flag) {
+                    return offset
+                } else {
+                    return nil
+                }
+            }.first
+        return row.map { IndexPath(row: $0, section: offset) }
+    }.first!

--- a/Tests/SwiftRewriterTests/Newline/MethodChainNewlinerTests.swift
+++ b/Tests/SwiftRewriterTests/Newline/MethodChainNewlinerTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import SwiftRewriter
+
+final class MethodChainNewlinerTests: XCTestCase
+{
+    func test_closure1() throws
+    {
+        let source = """
+            a
+                .b {
+                }.c
+            """
+
+        let expected = """
+            a
+                .b {
+                }
+            .c
+            """
+
+        try runTest(
+            source: source,
+            expected: expected,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_closure2() throws
+    {
+        let source = """
+            a
+                .b {
+                }.c {
+                }
+            """
+
+        let expected = """
+            a
+                .b {
+                }
+            .c {
+                }
+            """
+
+        try runTest(
+            source: source,
+            expected: expected,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_arg1() throws
+    {
+        let source = """
+            a
+                .b(
+                ).c
+            """
+
+        let expected = """
+            a
+                .b(
+                )
+            .c
+            """
+
+        try runTest(
+            source: source,
+            expected: expected,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_arg2() throws
+    {
+        let source = """
+            a
+                .b(
+                ).c(
+                )
+            """
+
+        let expected = """
+            a
+                .b(
+                )
+            .c(
+                )
+            """
+
+        try runTest(
+            source: source,
+            expected: expected,
+            using: MethodChainNewliner()
+        )
+    }
+
+    // MARK: - No Change
+
+    func test_noChange1() throws
+    {
+        let source = """
+            a.b.c
+            """
+
+        try runTest(
+            source: source,
+            expected: source,
+            using: MethodChainNewliner()
+        )
+    }
+
+    /// - Note: `b`'s closure requires
+    func test_noChange2() throws
+    {
+        let source = """
+            a
+                .b {}.c
+            """
+
+        try runTest(
+            source: source,
+            expected: source,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_noChange3() throws
+    {
+        let source = """
+            a
+                .b {}.c {
+                }
+            """
+
+        try runTest(
+            source: source,
+            expected: source,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_noChange4() throws
+    {
+        let source = """
+            a
+                .b().c
+            """
+
+        try runTest(
+            source: source,
+            expected: source,
+            using: MethodChainNewliner()
+        )
+    }
+
+    func test_noChange5() throws
+    {
+        let source = """
+            a
+                .b().c(
+                )
+            """
+
+        try runTest(
+            source: source,
+            expected: source,
+            using: MethodChainNewliner()
+        )
+    }
+}


### PR DESCRIPTION
This PR resolves "#5 Add newline while method-chaining".

## Examples

### Code from #5 

```diff
 observable
     .map { 
         $0
-    }.map {
+    }
+    .map {
         $0
     }
```

### Code in doc-comment

```diff
 foo
     .bar {
         // long block
-    }.baz
+    }
+    .baz
```

but **won't be newlined if not enough "long block"** ,
so that one-liner `foo().bar { }.baz` won't be newlined every time.
