### PR TITLE
Improve `HasRewriterExamples`

### DIFF
--- a/Sources/SwiftRewriter/Protocols/HasRewriterExamples.swift
+++ b/Sources/SwiftRewriter/Protocols/HasRewriterExamples.swift
@@ -3,5 +3,33 @@ import SwiftSyntax
 /// Supporting protocol for simple tests.
 protocol HasRewriterExamples
 {
+    /// Dictionary representing syntax changes from `key` to `value`.
     var rewriterExamples: [String: String] { get }
+
+    /// Array representing no syntax changes.
+    var rewriterNoChangeExamples: [String] { get }
+}
+
+extension HasRewriterExamples
+{
+    /// Default implementation.
+    var rewriterNoChangeExamples: [String]
+    {
+        return []
+    }
+}
+
+extension HasRewriterExamples
+{
+    /// `rewriterExamples` + `rewriterNoChangeExamples` for testing.
+    var rewriterAllExamples: [String: String]
+    {
+        let noChanges = [String: String](
+            rewriterNoChangeExamples.map { ($0, $0) },
+            uniquingKeysWith: { $1 }
+        )
+
+        return rewriterExamples
+            .merging(noChanges, uniquingKeysWith: { $1 })
+    }
 }

--- a/Sources/SwiftRewriter/Rewriters/Space/BinaryOperatorSpacer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Space/BinaryOperatorSpacer.swift
@@ -18,12 +18,6 @@ open class BinaryOperatorSpacer: SyntaxRewriter, HasRewriterExamples
 
     var rewriterExamples: [String: String]
     {
-        return _rewriterExamples
-            .merging(_rewriterExamplesNoChange, uniquingKeysWith: { $1 })
-    }
-
-    private var _rewriterExamples: [String: String]
-    {
         switch self._spacesAround {
         case true:
             return [
@@ -44,9 +38,9 @@ open class BinaryOperatorSpacer: SyntaxRewriter, HasRewriterExamples
         }
     }
 
-    private var _rewriterExamplesNoChange: [String: String]
+    var rewriterNoChangeExamples: [String]
     {
-        let noChanges = [
+        return [
             "reduce(+)", "reduce(+ )", "reduce( +)", "reduce( + )",
             "User.table[*]", "User.table[* ]", "User.table[ *]", "User.table[ * ]", // e.g. SQLite.swift
 
@@ -58,9 +52,7 @@ open class BinaryOperatorSpacer: SyntaxRewriter, HasRewriterExamples
             // UnknownDeclSyntax bug in SwiftSyntax
             "@available(*, deprecated, message: \"...\")",
             "@available( * , deprecated, message: \"...\")"
-            ]
-
-        return [String: String](noChanges.map { ($0, $0) }, uniquingKeysWith: { $1 })
+        ]
     }
 
     public init(spacesAround: Bool = true)

--- a/Sources/SwiftRewriter/Rewriters/Space/ColonSpacer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Space/ColonSpacer.swift
@@ -11,12 +11,6 @@ open class ColonSpacer: SyntaxRewriter, HasRewriterExamples
 
     var rewriterExamples: [String: String]
     {
-        return _rewriterExamples
-            .merging(_rewriterExamplesNoChange, uniquingKeysWith: { $1 })
-    }
-
-    private var _rewriterExamples: [String: String]
-    {
         switch (self._spaceBefore, self._spaceAfter) {
         case (true, true):
             return [
@@ -46,17 +40,15 @@ open class ColonSpacer: SyntaxRewriter, HasRewriterExamples
     }
 
     /// - Note: `if #available(..., *)` (UnknownStmtSyntax bug) will not be handled.
-    private var _rewriterExamplesNoChange: [String: String]
+    var rewriterNoChangeExamples: [String]
     {
-        let noChanges = [
+        return [
             "[:]",
             "[ : ]",
             "[: ]",
             "[ :]",
             "arr.map(State.init(rawValue:))"
             ]
-
-        return [String: String](noChanges.map { ($0, $0) }, uniquingKeysWith: { $1 })
     }
 
     public init(spaceBefore: Bool = false, spaceAfter: Bool = true)

--- a/Sources/SwiftRewriter/Rewriters/Space/LeftParenSpacer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Space/LeftParenSpacer.swift
@@ -13,12 +13,6 @@ open class LeftParenSpacer: SyntaxRewriter, HasRewriterExamples
 
     var rewriterExamples: [String: String]
     {
-        return _rewriterExamples
-            .merging(_rewriterExamplesNoChange, uniquingKeysWith: { $1 })
-    }
-
-    private var _rewriterExamples: [String: String]
-    {
         switch self._spaceBefore {
         case true:
             return [
@@ -39,16 +33,14 @@ open class LeftParenSpacer: SyntaxRewriter, HasRewriterExamples
         }
     }
 
-    private var _rewriterExamplesNoChange: [String: String]
+    var rewriterNoChangeExamples: [String]
     {
-        let noChanges = [
+        return [
             "func foo() {}",
             "func foo () {}",
             "init() {}",
             "init () {}",
             ]
-
-        return [String: String](noChanges.map { ($0, $0) }, uniquingKeysWith: { $1 })
     }
 
     public init(spaceBefore: Bool = true)

--- a/Tests/SwiftRewriterTests/Helpers/TestRunner.swift
+++ b/Tests/SwiftRewriterTests/Helpers/TestRunner.swift
@@ -13,7 +13,7 @@ func runExamples<T>(
     ) throws
     where T: SyntaxRewriterProtocol & HasRewriterExamples
 {
-    try rewriter.rewriterExamples
+    try rewriter.rewriterAllExamples
         .sorted(by: { $0.key < $1.key || ($0.key == $1.key && $0.value < $1.value) }) // lexicographical order
         .forEach { source, expected in
             try runTest(source: source, expected: expected, using: rewriter,


### PR DESCRIPTION
This PR improves `protocol HasRewriterExamples` by adding `rewriterNoChangeExamples` (array) so that it can be combined with `rewriterExamples` (dictionary) easily that removes boilerplate code.