### PR TITLE
Add `DecimalLiteralUnderscorer`

### DIFF
--- a/Sources/SwiftRewriter/Rewriters/Token/DecimalLiteralUnderscorer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Token/DecimalLiteralUnderscorer.swift
@@ -1,0 +1,56 @@
+import SwiftSyntax
+
+/// Insert `_`s for every 3-digits in decimal literal.
+open class DecimalLiteralUnderscorer: SyntaxRewriter, HasRewriterExamples
+{
+    var rewriterExamples: [String: String]
+    {
+        return [
+            "1000": "1_000",
+            "1000000": "1_000_000",
+            "1_0_0_0": "1_000",
+        ]
+    }
+
+    var rewriterNoChangeExamples: [String]
+    {
+        return [
+            "123",
+            "1_000",
+            "0x1000",
+            "0b1000",
+            "0o1000",
+            "1234.5"
+        ]
+    }
+
+    open override func visit(_ syntax: IntegerLiteralExprSyntax) -> ExprSyntax
+    {
+        var text = syntax.digits.text
+
+        // Ignore non-decimal-literals.
+        if text.hasPrefix("0x")
+            || text.hasPrefix("0b")
+            || text.hasPrefix("0o")
+        {
+            return super.visit(syntax)
+        }
+
+        text = text.replacingOccurrences(of: "_", with: "")
+
+        let limitedIndex = text.index(after: text.startIndex) // index = 1
+        var index = text.endIndex
+        while true {
+            if text.formIndex(&index, offsetBy: -3, limitedBy: limitedIndex) {
+                text.insert("_", at: index)
+            }
+            else {
+                break
+            }
+        }
+
+        let digits2 = syntax.digits.withKind(TokenKind.integerLiteral(text))
+
+        return super.visit(syntax.withDigits(digits2))
+    }
+}

--- a/Sources/swift-rewriter/rewriter.swift
+++ b/Sources/swift-rewriter/rewriter.swift
@@ -42,4 +42,7 @@ var rewriter: Rewriter {
         >>> LeftBraceSpacer(spaceBefore: true)
         >>> LeftParenSpacer(spaceBefore: true)
         >>> TrailingSpaceTrimmer()
+
+        // Token
+        >>> DecimalLiteralUnderscorer()
 }

--- a/Tests/SwiftRewriterTests/Token/DecimalLiteralUnderscorerTests.swift
+++ b/Tests/SwiftRewriterTests/Token/DecimalLiteralUnderscorerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import SwiftRewriter
+
+final class DecimalLiteralUnderscorerTests: XCTestCase
+{
+    func test_examples() throws
+    {
+        try runExamples(using: DecimalLiteralUnderscorer())
+    }
+}


### PR DESCRIPTION
This PR adds `DecimalLiteralUnderscorer` that adds `_` to decimal literal for every 3-digits.

### Examples

```swift
var rewriterExamples: [String: String]
{
    return [
        "1000": "1_000",
        "1000000": "1_000_000",
        "1_0_0_0": "1_000",
    ]
}

var rewriterNoChangeExamples: [String]
{
    return [
        "123",
        "1_000",
        "0x1000",
        "0b1000",
        "0o1000",
        "1234.5"
    ]
}
```