### PR TITLE
Add `SemicolonTrimmer`

### DIFF
--- a/Sources/SwiftRewriter/Extensions/Syntax.swift
+++ b/Sources/SwiftRewriter/Extensions/Syntax.swift
@@ -193,4 +193,9 @@ extension Syntax
         result.insert(contentsOf: parent.previousTokens(stop: f), at: 0)
         return result
     }
+
+    var isLastChild: Bool
+    {
+        return self.indexInParent == (self.parent?.numberOfChildren ?? 0) - 1
+    }
 }

--- a/Sources/SwiftRewriter/Rewriters/Token/SemicolonTrimmer.swift
+++ b/Sources/SwiftRewriter/Rewriters/Token/SemicolonTrimmer.swift
@@ -1,0 +1,50 @@
+import SwiftSyntax
+
+/// Trim `";"`s that appear at the last token of the line.
+open class SemicolonTrimmer: SyntaxRewriter, HasRewriterExamples
+{
+    var rewriterExamples: [String: String]
+    {
+        return [
+            "x = 1;": "x = 1",
+            "x = 1; y = 2;": "x = 1; y = 2",
+
+            // NOTE: semicolon's trailing space will also be deleted.
+            "struct Foo { let x = 1; }": "struct Foo { let x = 1}",
+            "struct Foo { let x = 1; let y = 2; }": "struct Foo { let x = 1; let y = 2}"
+        ]
+    }
+
+    var rewriterNoChangeExamples: [String]
+    {
+        return [
+            "x = 1; y = 2",
+            "struct Foo { let x = 1 }",
+            "struct Foo { let x = 1; let y = 2 }"
+        ]
+    }
+
+    open override func visit(_ syntax: CodeBlockItemSyntax) -> Syntax
+    {
+        if let nextToken = syntax.nextToken,
+            nextToken.leadingTrivia.contains(where: { $0.isNewline }) || syntax.isLastChild
+        {
+            return super.visit(syntax.withSemicolon(nil))
+        }
+        else {
+            return super.visit(syntax)
+        }
+    }
+
+    open override func visit(_ syntax: MemberDeclListItemSyntax) -> Syntax
+    {
+        if let nextToken = syntax.nextToken,
+            nextToken.leadingTrivia.contains(where: { $0.isNewline }) || syntax.isLastChild
+        {
+            return super.visit(syntax.withSemicolon(nil))
+        }
+        else {
+            return super.visit(syntax)
+        }
+    }
+}

--- a/Sources/swift-rewriter/rewriter.swift
+++ b/Sources/swift-rewriter/rewriter.swift
@@ -13,12 +13,16 @@ var rewriter: Rewriter {
         >>> ImportSorter()
 //        >>> ExtensionIniter() // not useful for everyone
 
-        // Newline
+        // Token
+        >>> DecimalLiteralUnderscorer()
+        >>> SemicolonTrimmer()
+
+        // Newline (whitespace)
 //        >>> ExtraNewliner()   // not useful for everyone
         >>> ElseNewliner(newline: false)
         >>> MethodChainNewliner()
 
-        // Indent
+        // Indent (whitespace)
         >>> Indenter(.init(
             perIndent: .spaces(4),
             shouldIndentSwitchCase: false,
@@ -27,7 +31,7 @@ var rewriter: Rewriter {
             usesXcodeStyle: true
             ))
 
-        // Space
+        // Space (whitespace)
 //        >>> ExtraSpaceTrimmer()   // may disturb manually-aligned code
 
         >>> ColonSpacer(spaceBefore: false, spaceAfter: true)
@@ -42,7 +46,4 @@ var rewriter: Rewriter {
         >>> LeftBraceSpacer(spaceBefore: true)
         >>> LeftParenSpacer(spaceBefore: true)
         >>> TrailingSpaceTrimmer()
-
-        // Token
-        >>> DecimalLiteralUnderscorer()
 }

--- a/Tests/SwiftRewriterTests/Token/SemicolonTrimmerTests.swift
+++ b/Tests/SwiftRewriterTests/Token/SemicolonTrimmerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import SwiftRewriter
+
+final class SemicolonTrimmerTests: XCTestCase
+{
+    func test_examples() throws
+    {
+        try runExamples(using: SemicolonTrimmer())
+    }
+}


### PR DESCRIPTION
cf. #11 

This PR adds `SemicolonTrimmer`, the easiest example ever!

## Examples

```swift
var rewriterExamples: [String: String]
{
    return [
        "x = 1;": "x = 1",
        "x = 1; y = 2;": "x = 1; y = 2",

         // NOTE: semicolon's trailing space will also be deleted.
        "struct Foo { let x = 1; }": "struct Foo { let x = 1}",
        "struct Foo { let x = 1; let y = 2; }": "struct Foo { let x = 1; let y = 2}"
    ]
}

var rewriterNoChangeExamples: [String]
{
    return [
        "x = 1; y = 2",
        "struct Foo { let x = 1 }",
        "struct Foo { let x = 1; let y = 2 }"
    ]
}
```