### PR TITLE
Better diff output for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ var rewriter: Rewriter {
      .code {
      }
      .format {
-−} // this!!!
+-} // this!!!
 +    } // this!!!
 ```
 
@@ -148,14 +148,14 @@ struct Foo {
 
 ```diff
 @@ −1,10 +1,2 @@
-−//
-−//  example.swift
-−//  SwiftRewriter
-−//
-−//  Created by Yasuhiro Inami on 2018-12-09.
-−//  Copyright © 2018 Yasuhiro Inami. All rights reserved.
-−//
-−
+-//
+-//  example.swift
+-//  SwiftRewriter
+-//
+-//  Created by Yasuhiro Inami on 2018-12-09.
+-//  Copyright © 2018 Yasuhiro Inami. All rights reserved.
+-//
+-
  // All your code are belong to us.
 ```
 


### PR DESCRIPTION
Right now the diff blocks are using a hyphen instead of a minus sign and so they aren't rendering as nicely as they could be.

There's a chance you got this hyphen from the output of the swift snapshot testing library. We use a hyphen instead of a minus sign so that things align nicely in the Xcode test failure, but unfortunately that isn't recognized by diff syntax highlighters.