### PR TITLE
Improve `GenericWhereClauseSyntax` indent

### DIFF
--- a/Sources/SwiftRewriter/Rewriters/Indent/Internal/BlockItemIndenter.swift
+++ b/Sources/SwiftRewriter/Rewriters/Indent/Internal/BlockItemIndenter.swift
@@ -604,6 +604,9 @@ class BlockItemIndenter: SyntaxRewriter, HasRewriterExamples
         return syntax2
     }
 
+    // MARK: WhereClauseSyntax
+
+    /// e.g. `case ... where ...`
     override func visit(_ syntax: WhereClauseSyntax) -> Syntax
     {
         var syntax2 = syntax
@@ -627,6 +630,29 @@ class BlockItemIndenter: SyntaxRewriter, HasRewriterExamples
 
         return syntax2
     }
+
+    // MARK: GenericWhereClauseSyntax
+
+    override func visit(_ syntax: GenericWhereClauseSyntax) -> Syntax
+    {
+        var syntax2 = syntax
+        var isIncremented: Bool = false
+
+        self._incrementIndentLevelIfNeeded(
+            lens: .whereKeyword,
+            syntax: &syntax2,
+            isIncremented: &isIncremented
+        )
+
+        self._visit(lens: .requirementList, syntax: &syntax2)
+
+        if isIncremented {
+            self._decrementIndentLevel(tag: syntax)
+        }
+
+        return syntax2
+    }
+
 
     // MARK: - ExprSyntax
 

--- a/Tests/SwiftRewriterTests/Indent/BlockItemIndenterTests.swift
+++ b/Tests/SwiftRewriterTests/Indent/BlockItemIndenterTests.swift
@@ -289,6 +289,49 @@ final class BlockItemIndenterTests: XCTestCase
         )
     }
 
+    func test_genericWhereClause() throws
+    {
+        let source = """
+            struct Foo<T>
+            where T: Equatable {
+            }
+            enum Foo<T>
+            where T: Equatable {
+            }
+            class Foo<T>
+            where T: Equatable {
+            }
+            protocol P
+            where Self: UIView {
+            associatedtype Sub: SubP
+            where Self.Element == Self.SubP.Element
+            }
+            """
+
+        let expected = """
+            struct Foo<T>
+                where T: Equatable {
+            }
+            enum Foo<T>
+                where T: Equatable {
+            }
+            class Foo<T>
+                where T: Equatable {
+            }
+            protocol P
+                where Self: UIView {
+                associatedtype Sub: SubP
+                    where Self.Element == Self.SubP.Element
+            }
+            """
+
+        try runTest(
+            source: source,
+            expected: expected,
+            using: BlockItemIndenter()
+        )
+    }
+
     // NOTE: `FirstItemAwareIndenter` handles better indent.
     func test_tuplePatternElementList() throws
     {


### PR DESCRIPTION
### Example

```swift
struct Foo<T>
    where T: Equatable {
}

enum Foo<T>
    where T: Equatable {
}

class Foo<T>
    where T: Equatable {
}

protocol P
    where Self: UIView {
    associatedtype Sub: SubP
        where Self.Element == Self.SubP.Element
}
```